### PR TITLE
P6: wire tool-pane intents and legacy panel bridge (#76)

### DIFF
--- a/shell/desktop/ui/toolbar/toolbar_settings_menu.rs
+++ b/shell/desktop/ui/toolbar/toolbar_settings_menu.rs
@@ -4,6 +4,7 @@ use crate::app::{
 };
 use crate::shell::desktop::host::running_app_state::{RunningAppState, UserInterfaceCommand};
 use crate::shell::desktop::host::window::EmbedderWindow;
+use crate::shell::desktop::workbench::pane_model::ToolPaneState;
 use egui::Slider;
 
 pub(super) fn render_settings_menu(
@@ -18,6 +19,9 @@ pub(super) fn render_settings_menu(
 ) {
     if ui.button("Open Persistence Hub").clicked() {
         graph_app.workspace.show_persistence_panel = true;
+        frame_intents.push(GraphIntent::OpenToolPane {
+            kind: ToolPaneState::Settings,
+        });
         ui.close();
     }
     if ui
@@ -50,7 +54,13 @@ pub(super) fn render_settings_menu(
         })
         .clicked()
     {
+        let opening = !graph_app.workspace.show_history_manager;
         frame_intents.push(GraphIntent::ToggleHistoryManager);
+        if opening {
+            frame_intents.push(GraphIntent::OpenToolPane {
+                kind: ToolPaneState::HistoryManager,
+            });
+        }
         ui.close();
     }
     ui.separator();


### PR DESCRIPTION
## Summary
Implements a narrow `#76` slice for pane-hosted tool intent wiring and a legacy panel bridge.

## Issues
- Closes #76

## Lane
- `lane:p6`

## What changed
- Added workbench-layer handling for `GraphIntent::OpenToolPane` in the GUI frame loop (before semantic reducer apply)
- Generalized diagnostics pane opening into `open_or_focus_tool_pane(...)` keyed by `ToolPaneState`
- Bridged legacy panel flags to pane-hosted tool panes:
  - History Manager -> `ToolPaneState::HistoryManager`
  - Persistence/Sync panel requests -> `ToolPaneState::Settings`
- Updated toolbar settings actions to emit `OpenToolPane` for history/persistence paths while preserving legacy toggles

## Hot files touched
- `shell/desktop/ui/gui.rs`
- `shell/desktop/ui/toolbar/toolbar_settings_menu.rs`

## Stack / Dependencies
- Base PR in `lane:p6`
- Follow-up expected: `#77` (tool-pane render/title/focus dispatch by `ToolPaneState`)
- Not stack-dependent on an open PR (targets `main`)

## Validation
- `cargo check -q` (passes, warnings only)

## Notes
- This intentionally does not implement per-tool rendering/title behavior yet; it only wires the intent/open/focus path and compatibility bridge.
