### PR TITLE
Document the published Graphshell lineage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,5 +66,6 @@ scene, routed relations, and content-addressed card offers, and maps advertised
 intents back through Merecat's Servitor gate. Graphshell gains only the generic
 spatial receipt view; this repository still has no Mere or Merecat dependency.
 
-The donor repository must be renamed and its live citations repaired before
-this local G0 workspace is published under the Graphshell name.
+The portable workspace was published on 2026-07-22 as the active Graphshell
+tree. The retired browser donor remains intact in this repository's Git
+history rather than appearing as current source or documentation.


### PR DESCRIPTION
## Summary

- remove the obsolete publication gate from the README
- record that the portable workspace is active on `main`
- clarify that the retired browser donor and its design documents remain available in Git history

## Verification

Documentation-only follow-up to #308. The previously verified source tree is unchanged.